### PR TITLE
removed links to dead meetups

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -29,7 +29,6 @@
 
       <navh><strong>Affiliated Meetups</strong></navh>
       <a class="sidebar-nav-item" href="http://www.meetup.com/Portland-Data-Science-Group/">PDX Data Science Group</a>
-      <a class="sidebar-nav-item" href="http://www.meetup.com/Portland-Data/">PDX Data</a>
       <a class="sidebar-nav-item" href="http://www.meetup.com/PDX-Data-Engineering/">PDX Data Engineering</a>
       <a class="sidebar-nav-item" href="https://www.meetup.com/MarTech-PDX-Marketing-Technology-Group/">PDX MarTech</a>
       <a class="sidebar-nav-item" href="http://www.meetup.com/portland-r-user-group/">PDX R User Group</a>

--- a/about.md
+++ b/about.md
@@ -8,13 +8,11 @@ target: http://pdxdata.github.io/about
 Welcome to PDX Data Science
 ===========
 
-We're about data and openness. We are a consortium of independnet Meetups that are part of the larger data science conversation in Portland. This site collects links to all the talks (and data!) from recent events and helps you connect to the conversation. 
+We're about data and openness. We are a consortium of independnet Meetups that are part of the larger data science conversation in Portland. This site collects links to all the talks (and data!) from recent events and helps you connect to the conversation.
 
 The current members of this Meetup Consortium are:
 
 * [Portland Data Science Group](http://www.meetup.com/Portland-Data-Science-Group/)
-* [Portland Data](http://www.meetup.com/Portland-Data/)
-* [Portland Data User Group](http://www.meetup.com/Portland-Data-User-Group/)
 * [PDX Data Engineering](http://www.meetup.com/PDX-Data-Engineering/)
 * [PDX MarTech](https://www.meetup.com/MarTech-PDX-Marketing-Technology-Group/)
 * [Portland R user Group](http://www.meetup.com/portland-r-user-group/)


### PR DESCRIPTION
The Meetups "Portland Data" and "Portland Data User Group" are no longer valid (dead links), removed them from sidebar and about page.